### PR TITLE
rename to networkStat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# netstat
+# networkStat
 No-dependnency command line util for checking network status
 
 ## Installation
@@ -6,7 +6,7 @@ No-dependnency command line util for checking network status
 - Run the command `npm install -g`
 
 ## Usage
-- After installation just type `netstat` in your terminal
+- After installation just type `networkStat` in your terminal
 - Tada! It displays current status of network and displays
     1. Local network address
     2. IP address
@@ -16,7 +16,7 @@ No-dependnency command line util for checking network status
 ## Why only port 3000 ?
 - Because it is frequently used port by starter packs and it is quite annoying to run your custom built projects to check if there is a project and check terminals
 
-- But you still can check if there is another port available by just typing port number like `netstat 8000` 
+- But you still can check if there is another port available by just typing port number like `networkStat 8000` 
 
 ## Like it ?
 Cool. Glad that you liked it.Can you star the project?(Trust me, it helps a lot). Thank you!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "networkstat",
+  "version": "0.0.3",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkstat",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "simple util command ",
   "main": "src/index.js",
   "scripts": {
@@ -10,7 +10,10 @@
   "license": "MIT",
   "preferGlobal": true,
   "bin": {
-    "netstat": "src/index.js"
+    "networkStat": "src/index.js"
   },
-  "engines": {"node": "*"}
+  "engines": {
+    "node": "*"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Rename the command name to `networkStat` to avoid conflicts with native commands of OS