### PR TITLE
replace finally with then to support node 8

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ let isOnline;
 checkTCP()
     .then(() => (isOnline = true))
     .catch(() => (isOnline = false))
-    .finally(() => console.log(`Connected to Internet: ${isOnline ? FgGreen : FgRed}`, `${isOnline}`));
+    .then(() => console.log(`Connected to Internet: ${isOnline ? FgGreen : FgRed}`, `${isOnline}`));
 
 let requiredAddr = [];
 


### PR DESCRIPTION
It seems `finally()` of TCP connection does not work in node 8 version. this is meant to be fix for the issue